### PR TITLE
The enforcement of valid file extensions has been deactivated

### DIFF
--- a/CHANGELOG.de.md
+++ b/CHANGELOG.de.md
@@ -1,0 +1,7 @@
+# Stream-Context
+
+## 0.1.0
+ - Erstveröffentlichung  
+
+## 0.1.1
+ - Das Erzwingen von validen Dateiendungen wurde für File-URL's ohne explizite Dateiendung wie z.B "http://example.com/fetch_some_stream" deaktiviert.  

--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -1,0 +1,7 @@
+# Stream-Context
+
+## 0.1.0
+- Initial release
+
+## 0.1.1
+- The enforcement of valid file extensions has been deactivated for file URLs without an explicit file extension such as ‘http://example.com/fetch_some_stream’.

--- a/composer.json
+++ b/composer.json
@@ -1,37 +1,27 @@
 {
-    "name": "artemeon/stream-context",
-    "license": "MIT",
-    "type": "library",
-    "description": "Library to create a stream context",
-    "keywords": [
-        "php7",
-        "stream",
-        "context"
-    ],
-    "authors": [
-        {
-            "name": "Dietmar Simons",
-            "email": "dietmar.simons@artemeon.de"
-        }
-    ],
-    "config": {
-        "bin-dir": "bin"
-    },
-    "autoload": {
-        "psr-4": {
-            "Artemeon\\StreamContext\\": "src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Artemeon\\StreamContext\\Tests\\": "tests/"
-        }
-    },
-    "require": {
-        "php": ">=7.4",
-        "phpseclib/phpseclib": "~3.0"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "^8.0"
+  "name": "artemeon/stream-context",
+  "version": "0.1.1",
+  "license": "MIT",
+  "type": "library",
+  "description": "Library to create a stream context",
+  "keywords": [
+    "php7",
+    "stream",
+    "context"
+  ],
+  "authors": [
+    {
+      "name": "Dietmar Simons",
+      "email": "dietmar.simons@artemeon.de"
     }
+  ],
+  "autoload": {
+    "psr-4": {
+      "Artemeon\\StreamContext\\": "src/"
+    }
+  },
+  "require": {
+    "php": ">=7.4",
+    "phpseclib/phpseclib": "~3.0"
+  }
 }


### PR DESCRIPTION
The enforcement of valid file extensions has been deactivated for file URLs without an explicit file extension such as ‘http://example.com/fetch_some_stream’.